### PR TITLE
Fixed duplicate:true issue for paramitarized routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,11 +152,11 @@ p.go = function(routeStr) {
 	// if this is not a section descriptor or it is a descriptor and we should updateURL
 	if( global.location && doURLChange ) {
 
-		global.location.hash = newURL;
-
-		// Check if duplicate is set. The check is done here since, onhashchange event triggers 
-		// only when url changes and therefore cannot check to allow duplicate/repeating route
-		if(section.duplicate) {
+		if(global.location.hash.replace(/^#/, '') != newURL) {
+			global.location.hash = newURL;
+		} else if(section.duplicate){
+			// Check if duplicate is set. The check is done here since, onhashchange event triggers 
+			// only when url changes and therefore cannot check to allow duplicate/repeating route
 			this.doRoute(routeData, section);
 		}
 	} else if( !global.location || !doURLChange ) {

--- a/index.js
+++ b/index.js
@@ -154,11 +154,14 @@ p.go = function(routeStr) {
 
 		if(global.location.hash.replace(/^#/, '') != newURL) {
 			global.location.hash = newURL;
-		} else if(section.duplicate){
+		} else if(section.duplicate || !section.useURL) {
 			// Check if duplicate is set. The check is done here since, onhashchange event triggers 
 			// only when url changes and therefore cannot check to allow duplicate/repeating route
+
+			// Additionally check if useURL is set to false. If not, the route is not triggered by
+			// url changes
 			this.doRoute(routeData, section);
-		}
+		} 
 	} else if( !global.location || !doURLChange ) {
 		this.doRoute(routeData, section);
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -92,14 +92,16 @@ test( 'testing router', function( t ) {
 		'/': sectionRoot,
 		'/about': { section: sectionAbout, useURL: false },
 		'/info': sectionInfo,
-		'/gallery/:image': sectionGallery,
+		'/gallery/:image':  { section: sectionGallery, duplicate: true },
 		'/redirect': '/',
 		'404': section404
 	});
 
-
 	router.on('route', function(info) {
-		tests.shift()(info.section, info.route);
+		// Using 500ms to not interfere with another test case
+		setTimeout(function() {
+			tests.shift()(info.section, info.route);
+		},500);
 	});
 
 	router.init();


### PR DESCRIPTION
When a route with a parameter has duplicate set to true, it will fire two emits when going to that route:

1. Hash Change causes a doRoute

2. section.duplicate causes another doRoute

Note that this cannot be detected by the current test cases as there are race conditions happening. Hash change events are happening on later test cases that may overlap the previous one. Setting a timeout before each test case execute reveals this.